### PR TITLE
added initial systemd service file for metadatasvc

### DIFF
--- a/rocket-metadata.service
+++ b/rocket-metadata.service
@@ -1,0 +1,11 @@
+#
+# 
+#
+[Unit]
+Description=Rocket Metadata Service
+
+[Service]
+ExecStart=/usr/bin/rkt metadata-service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When added to a systemd based linux host, enabled and started, this file will ensure that the Rocket metadata service is started at boot time.
